### PR TITLE
Ps weightfix

### DIFF
--- a/GeneratorInterface/Core/interface/WeightHelper.h
+++ b/GeneratorInterface/Core/interface/WeightHelper.h
@@ -62,6 +62,7 @@ namespace gen {
     void updateScaleInfo(gen::ScaleWeightGroupInfo& scaleGroup, const ParsedWeight& weight);
     void updateMEParamInfo(const ParsedWeight& weight, int index);
     void updatePdfInfo(gen::PdfWeightGroupInfo& pdfGroup, const ParsedWeight& weight);
+    void updatePartonShowerInfo(gen::PartonShowerWeightGroupInfo& psGroup, const ParsedWeight& weight);
     void cleanupOrphanCentralWeight();
     bool splitPdfWeight(ParsedWeight& weight);
 

--- a/GeneratorInterface/Core/interface/WeightHelper.h
+++ b/GeneratorInterface/Core/interface/WeightHelper.h
@@ -35,6 +35,9 @@ namespace gen {
     std::unique_ptr<GenWeightProduct> weightProduct(std::vector<T> weights, float w0);
 
     void setModel(std::string model) { model_ = model; }
+    void setGuessPSWeightIdx(bool guessPSWeightIdx) {
+      PartonShowerWeightGroupInfo::setGuessPSWeightIdx(guessPSWeightIdx);
+    }
     void addUnassociatedGroup() {
       weightGroups_.push_back(std::make_unique<UnknownWeightGroupInfo>("unassociated"));
       weightGroups_.back().setDescription("Weights missing or with invalid header meta data");

--- a/GeneratorInterface/Core/plugins/GenWeightProductProducer.cc
+++ b/GeneratorInterface/Core/plugins/GenWeightProductProducer.cc
@@ -51,6 +51,7 @@ GenWeightProductProducer::GenWeightProductProducer(const edm::ParameterSet& iCon
           mayConsume<GenLumiInfoHeader, edm::InLumi>(iConfig.getParameter<edm::InputTag>("genLumiInfoHeader"))) {
   produces<GenWeightProduct>();
   produces<GenWeightInfoProduct, edm::Transition::BeginLuminosityBlock>();
+  weightHelper_.setGuessPSWeightIdx(iConfig.getUntrackedParameter<bool>("guessPSWeightIdx", false));
 }
 
 GenWeightProductProducer::~GenWeightProductProducer() {}
@@ -82,8 +83,8 @@ void GenWeightProductProducer::beginLuminosityBlockProduce(edm::LuminosityBlock&
 
   auto weightInfoProduct = std::make_unique<GenWeightInfoProduct>();
   if (weightHelper_.weightGroups().size() == 0)
-      weightHelper_.addUnassociatedGroup();
-  
+    weightHelper_.addUnassociatedGroup();
+
   for (auto& weightGroup : weightHelper_.weightGroups()) {
     weightInfoProduct->addWeightGroupInfo(std::make_unique<gen::WeightGroupInfo>(*weightGroup.clone()));
   }

--- a/GeneratorInterface/Core/src/GenWeightHelper.cc
+++ b/GeneratorInterface/Core/src/GenWeightHelper.cc
@@ -17,6 +17,7 @@ namespace gen {
       return;
 
     for (std::string weightName : weightNames) {
+      std::cout << weightName << std::endl;
       if (weightName.find("LHE") != std::string::npos) {
         // Parse as usual, this is the SUSY workflow
         std::vector<std::string> info;
@@ -31,6 +32,7 @@ namespace gen {
             attributes[boost::algorithm::trim_copy(subInfo[0])] = boost::algorithm::trim_copy(subInfo[1]);
           }
         }
+        std::cout << "group: " << attributes["group"] << std::endl;
         if (attributes["group"] != curGroup) {
           curGroup = attributes["group"];
           groupIndex++;
@@ -43,7 +45,7 @@ namespace gen {
             {"", index, weightName, weightName, std::unordered_map<std::string, std::string>(), groupIndex});
         if (isPartonShowerWeightGroup(parsedWeights_.back())) {
           if (showerGroupIndex < 0) {
-              showerGroupIndex = ++groupIndex;
+            showerGroupIndex = ++groupIndex;
           }
           parsedWeights_.back().wgtGroup_idx = showerGroupIndex;  // all parton showers are grouped together
         }

--- a/GeneratorInterface/Core/src/GenWeightHelper.cc
+++ b/GeneratorInterface/Core/src/GenWeightHelper.cc
@@ -17,7 +17,6 @@ namespace gen {
       return;
 
     for (std::string weightName : weightNames) {
-      std::cout << weightName << std::endl;
       if (weightName.find("LHE") != std::string::npos) {
         // Parse as usual, this is the SUSY workflow
         std::vector<std::string> info;
@@ -32,7 +31,6 @@ namespace gen {
             attributes[boost::algorithm::trim_copy(subInfo[0])] = boost::algorithm::trim_copy(subInfo[1]);
           }
         }
-        std::cout << "group: " << attributes["group"] << std::endl;
         if (attributes["group"] != curGroup) {
           curGroup = attributes["group"];
           groupIndex++;

--- a/GeneratorInterface/Core/src/WeightHelper.cc
+++ b/GeneratorInterface/Core/src/WeightHelper.cc
@@ -157,6 +157,14 @@ namespace gen {
     pdfGroup.addLhaid(lhaid);
   }
 
+  void WeightHelper::updatePartonShowerInfo(gen::PartonShowerWeightGroupInfo& psGroup, const ParsedWeight& weight) {
+    if (psGroup.containedIds().size() == DEFAULT_PSWEIGHT_LENGTH)
+      psGroup.setIsWellFormed(true);
+    std::cout << weight.content << std::endl;
+    if (weight.content.find(":") != std::string::npos && weight.content.find("=") != std::string::npos)
+      psGroup.setNameIsPythiaSyntax(true);
+  }
+
   bool WeightHelper::splitPdfWeight(ParsedWeight& weight) {
     if (weightGroups_[weight.wgtGroup_idx].weightType() == gen::WeightType::kPdfWeights) {
       auto& pdfGroup = dynamic_cast<gen::PdfWeightGroupInfo&>(weightGroups_[weight.wgtGroup_idx]);
@@ -284,26 +292,59 @@ namespace gen {
         std::cout << wgt.description() << "\n";
       } else if (wgt.weightType() == gen::WeightType::kPartonShowerWeights) {
         auto& wgtPS = dynamic_cast<gen::PartonShowerWeightGroupInfo&>(wgt);
-        if (wgtPS.containedIds().size() == DEFAULT_PSWEIGHT_LENGTH)
-          wgtPS.setIsWellFormed(true);
-
-        wgtPS.cacheWeightIndicesByLabel();
         std::vector<std::string> labels = wgtPS.weightLabels();
-        if (labels.size() > FIRST_PSWEIGHT_ENTRY && labels.at(FIRST_PSWEIGHT_ENTRY).find(":") != std::string::npos &&
-            labels.at(FIRST_PSWEIGHT_ENTRY).find("=") != std::string::npos) {
-          wgtPS.setNameIsPythiaSyntax(true);
+        wgtPS.cacheWeightIndicesByLabel();
+
+        auto vars = {std::make_pair<bool, bool>(true, true),
+                     std::make_pair<bool, bool>(true, false),
+                     std::make_pair<bool, bool>(false, true),
+                     std::make_pair<bool, bool>(false, false)};
+        typedef gen::PSVarType varType;
+        typedef gen::PSSplittingType sptType;
+        std::vector<std::pair<varType, sptType>> ps_pairs = {
+            {varType::def, sptType::combined},
+            {varType::red, sptType::combined},
+            {varType::con, sptType::combined},
+            {varType::muR, sptType::g2gg},
+            {varType::muR, sptType::g2qq},
+            {varType::muR, sptType::q2qg},
+            {varType::muR, sptType::x2xg},
+            {varType::cNS, sptType::g2gg},
+            {varType::cNS, sptType::g2qq},
+            {varType::cNS, sptType::q2qg},
+            {varType::cNS, sptType::x2xg},
+        };
+        std::map<varType, std::string> varTypeMap = {
+            {varType::muR, "muR"},
+            {varType::cNS, "cNS"},
+            {varType::con, "con"},
+            {varType::def, "def"},
+            {varType::red, "red"},
+        };
+        std::map<sptType, std::string> splTypeMap = {
+            {sptType::combined, "combined"}, {sptType::g2gg, "g2gg"}, {sptType::x2xg, "x2xg"}, {sptType::g2qq, "g2qq"}};
+
+        for (auto [vartype, spttype] : ps_pairs) {
+          for (auto var : vars) {
+            int idx = wgtPS.variationIndex(var.first, var.second, vartype, spttype);
+            if (idx == -1)
+              continue;
+            std::cout << varTypeMap[vartype] << " " << splTypeMap[spttype] << "(" << var.first << ", " << var.second
+                      << "): " << idx << " - " << labels.at(idx) << std::endl;
+          }
         }
       }
       if (!wgt.isWellFormed())
         std::cout << "\033[0m";
     }
+    exit(0);
   }
 
   std::unique_ptr<WeightGroupInfo> WeightHelper::buildGroup(ParsedWeight& weight) {
-    if (debug_) {
-      std::cout << "Building group for weight group " << weight.groupname << " weight content is " << weight.content
-                << std::endl;
-    }
+    // if (debug_) {
+    //   std::cout << "Building group for weight group " << weight.groupname << " weight content is " << weight.content
+    //             << std::endl;
+    // }
     if (isScaleWeightGroup(weight))
       return std::make_unique<ScaleWeightGroupInfo>(weight.groupname);
     else if (isPdfWeightGroup(weight))
@@ -323,9 +364,9 @@ namespace gen {
     int groupOffset = 0;
     for (auto& weight : parsedWeights_) {
       weight.wgtGroup_idx += groupOffset;
-      if (debug_)
-        std::cout << "Building group for weight " << weight.content << " group " << weight.groupname << " group index "
-                  << weight.wgtGroup_idx << std::endl;
+      // if (debug_)
+      //   std::cout << "Building group for weight " << weight.content << " group " << weight.groupname << " group index "
+      //             << weight.wgtGroup_idx << std::endl;
 
       int numGroups = static_cast<int>(weightGroups_.size());
       if (weight.wgtGroup_idx == numGroups) {
@@ -341,9 +382,10 @@ namespace gen {
       group.addContainedId(weight.index, weight.id, weight.content);
       if (group.weightType() == gen::WeightType::kScaleWeights)
         updateScaleInfo(dynamic_cast<gen::ScaleWeightGroupInfo&>(group), weight);
-      else if (group.weightType() == gen::WeightType::kPdfWeights) {
+      else if (group.weightType() == gen::WeightType::kPdfWeights)
         updatePdfInfo(dynamic_cast<gen::PdfWeightGroupInfo&>(group), weight);
-      }
+      else if (group.weightType() == gen::WeightType::kPartonShowerWeights)
+        updatePartonShowerInfo(dynamic_cast<gen::PartonShowerWeightGroupInfo&>(group), weight);
     }
     cleanupOrphanCentralWeight();
   }

--- a/GeneratorInterface/Core/src/WeightHelper.cc
+++ b/GeneratorInterface/Core/src/WeightHelper.cc
@@ -89,7 +89,7 @@ namespace gen {
     } catch (std::invalid_argument& e) {
       if (debug_)
         std::cout << "Tried to convert (" << muR << ", " << muF << ") to a int" << std::endl;
-      scaleGroup.setIsWellFormed(false);
+      scaleGroup.setWeightIsCorrupt();
       return;
       /// do something
     }
@@ -103,7 +103,7 @@ namespace gen {
         scaleGroup.setDyn(weight.index, weight.id, muR, muF, dynNum, dynType);
       } catch (std::invalid_argument& e) {
         std::cout << "Tried to convert (" << dynNumText << ")  a int" << std::endl;
-        scaleGroup.setIsWellFormed(false);
+        scaleGroup.setWeightIsCorrupt();
         /// do something here
       }
     }

--- a/GeneratorInterface/Core/src/WeightHelper.cc
+++ b/GeneratorInterface/Core/src/WeightHelper.cc
@@ -86,7 +86,7 @@ namespace gen {
     try {
       muR = std::stof(muRText);
       muF = std::stof(muFText);
-    } catch (...) {
+    } catch (std::invalid_argument& e) {
       if (debug_)
         std::cout << "Tried to convert (" << muR << ", " << muF << ") to a int" << std::endl;
       scaleGroup.setIsWellFormed(false);
@@ -101,7 +101,7 @@ namespace gen {
       try {
         int dynNum = std::stoi(dynNumText);
         scaleGroup.setDyn(weight.index, weight.id, muR, muF, dynNum, dynType);
-      } catch (...) {
+      } catch (std::invalid_argument& e) {
         std::cout << "Tried to convert (" << dynNumText << ")  a int" << std::endl;
         scaleGroup.setIsWellFormed(false);
         /// do something here
@@ -112,8 +112,8 @@ namespace gen {
       std::string lhaidText = searchAttributes("pdf", weight);
       try {
         scaleGroup.setLhaid(std::stoi(lhaidText));
-      } catch (...) {
-        scaleGroup.setLhaid(-2);
+      } catch (std::invalid_argument& e) {
+        scaleGroup.setLhaid(-1);
         // do something here
       }
     }
@@ -160,7 +160,6 @@ namespace gen {
   void WeightHelper::updatePartonShowerInfo(gen::PartonShowerWeightGroupInfo& psGroup, const ParsedWeight& weight) {
     if (psGroup.containedIds().size() == DEFAULT_PSWEIGHT_LENGTH)
       psGroup.setIsWellFormed(true);
-    std::cout << weight.content << std::endl;
     if (weight.content.find(":") != std::string::npos && weight.content.find("=") != std::string::npos)
       psGroup.setNameIsPythiaSyntax(true);
   }
@@ -260,8 +259,6 @@ namespace gen {
   void WeightHelper::printWeights() {
     // checks
     for (auto& wgt : weightGroups_) {
-      if (!wgt.isWellFormed())
-        std::cout << "\033[1;31m";
       std::cout << std::boolalpha << wgt.name() << " (" << wgt.firstId() << "-" << wgt.lastId()
                 << "): " << wgt.isWellFormed() << std::endl;
       if (wgt.weightType() == gen::WeightType::kScaleWeights) {
@@ -334,17 +331,14 @@ namespace gen {
           }
         }
       }
-      if (!wgt.isWellFormed())
-        std::cout << "\033[0m";
     }
-    exit(0);
   }
 
   std::unique_ptr<WeightGroupInfo> WeightHelper::buildGroup(ParsedWeight& weight) {
-    // if (debug_) {
-    //   std::cout << "Building group for weight group " << weight.groupname << " weight content is " << weight.content
-    //             << std::endl;
-    // }
+    if (debug_) {
+      std::cout << "Building group for weight group " << weight.groupname << " weight content is " << weight.content
+                << std::endl;
+    }
     if (isScaleWeightGroup(weight))
       return std::make_unique<ScaleWeightGroupInfo>(weight.groupname);
     else if (isPdfWeightGroup(weight))
@@ -364,9 +358,9 @@ namespace gen {
     int groupOffset = 0;
     for (auto& weight : parsedWeights_) {
       weight.wgtGroup_idx += groupOffset;
-      // if (debug_)
-      //   std::cout << "Building group for weight " << weight.content << " group " << weight.groupname << " group index "
-      //             << weight.wgtGroup_idx << std::endl;
+      if (debug_)
+        std::cout << "Building group for weight " << weight.content << " group " << weight.groupname << " group index "
+                  << weight.wgtGroup_idx << std::endl;
 
       int numGroups = static_cast<int>(weightGroups_.size());
       if (weight.wgtGroup_idx == numGroups) {

--- a/PhysicsTools/NanoAOD/python/nanogen_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanogen_cff.py
@@ -9,11 +9,13 @@ from PhysicsTools.NanoAOD.lheWeightsTable_cfi import *
 
 genWeights = cms.EDProducer("GenWeightProductProducer",
     genInfo = cms.InputTag("generator"),
-    genLumiInfoHeader = cms.InputTag("generator"))
+    genLumiInfoHeader = cms.InputTag("generator"),
+    guessPSWeightIdx = cms.untracked.bool(True))
 
 lheWeights = cms.EDProducer("LHEWeightProductProducer",
     lheSourceLabels = cms.vstring(["externalLHEProducer", "source"]),
-    failIfInvalidXML = cms.untracked.bool(True)
+    failIfInvalidXML = cms.untracked.bool(True),
+
     #lheWeightSourceLabels = cms.vstring(["externalLHEProducer", "source"])
 )
 '''

--- a/SimDataFormats/GeneratorProducts/interface/PartonShowerWeightGroupInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/PartonShowerWeightGroupInfo.h
@@ -31,38 +31,36 @@ namespace gen {
     int variationIndex(bool isISR, bool isUp, PSVarType variationType, PSSplittingType splittingType) const;
     std::string variationName(bool isISR, bool isUp, PSVarType variationType, PSSplittingType splittingType) const;
     int variationIndex(bool isISR, bool isUp, PSVarType variationType) const;
+    static void setGuessPSWeightIdx(bool guessPSWeightIdx) { guessPSWeightIdx_ = guessPSWeightIdx_; }
+    int psWeightIdxGuess(const std::string &varName) const;
 
   private:
     bool nameIsPythiaSyntax_ = false;
-    typedef PSVarType varType;
-    typedef PSSplittingType sptType;
-    // Order determined by !isUp*2 + !isISR -> isrHi, fsrHi, isrLo, fsrLo
-    const std::unordered_map<PSPair, std::vector<int>, PSPairHash> oldPythia_order = {
-        {{varType::def, sptType::combined}, {6, 7, 8, 9}},
-        {{varType::red, sptType::combined}, {2, 3, 4, 5}},
-        {{varType::con, sptType::combined}, {10, 11, 12, 13}},
-        {{varType::muR, sptType::g2gg}, {31, 15, 30, 14}},
-        {{varType::muR, sptType::g2qq}, {33, 17, 32, 16}},
-        {{varType::muR, sptType::q2qg}, {35, 19, 34, 18}},
-        {{varType::muR, sptType::x2xg}, {37, 21, 36, 20}},
-        {{varType::cNS, sptType::g2gg}, {39, 23, 38, 22}},
-        {{varType::cNS, sptType::g2qq}, {41, 25, 40, 24}},
-        {{varType::cNS, sptType::q2qg}, {43, 27, 42, 26}},
-        {{varType::cNS, sptType::x2xg}, {45, 29, 44, 28}},
-    };
+    static inline bool guessPSWeightIdx_ = false;
 
-    const std::unordered_map<PSPair, std::vector<int>, PSPairHash> newPythia_order = {
-        {{varType::def, sptType::combined}, {27, 5, 26, 4}},
-        {{varType::red, sptType::combined}, {25, 3, 2, 24}},
-        {{varType::con, sptType::combined}, {29, 7, 28, 6}},
-        {{varType::muR, sptType::g2gg}, {31, 9, 30, 8}},
-        {{varType::muR, sptType::g2qq}, {33, 11, 32, 10}},
-        {{varType::muR, sptType::q2qg}, {35, 13, 34, 12}},
-        {{varType::muR, sptType::x2xg}, {37, 15, 36, 14}},
-        {{varType::cNS, sptType::g2gg}, {39, 17, 38, 16}},
-        {{varType::cNS, sptType::g2qq}, {41, 19, 40, 18}},
-        {{varType::cNS, sptType::q2qg}, {43, 21, 42, 20}},
-        {{varType::cNS, sptType::x2xg}, {45, 23, 44, 22}},
+    const std::vector<std::string> expectedPythiaSyntax = {
+        "fsr:murfac=0.707",    "fsr:murfac=1.414",    "fsr:murfac=0.5",      "fsr:murfac=2.0",
+        "fsr:murfac=0.25",     "fsr:murfac=4.0",      "fsr:g2gg:murfac=0.5", "fsr:g2gg:murfac=2.0",
+        "fsr:g2qq:murfac=0.5", "fsr:g2qq:murfac=2.0", "fsr:q2qg:murfac=0.5", "fsr:q2qg:murfac=2.0",
+        "fsr:x2xg:murfac=0.5", "fsr:x2xg:murfac=2.0", "fsr:g2gg:cns=-2.0",   "fsr:g2gg:cns=2.0",
+        "fsr:g2qq:cns=-2.0",   "fsr:g2qq:cns=2.0",    "fsr:q2qg:cns=-2.0",   "fsr:q2qg:cns=2.0",
+        "fsr:x2xg:cns=-2.0",   "fsr:x2xg:cns=2.0",    "isr:murfac=0.707",    "isr:murfac=1.414",
+        "isr:murfac=0.5",      "isr:murfac=2.0",      "isr:murfac=0.25",     "isr:murfac=4.0",
+        "isr:g2gg:murfac=0.5", "isr:g2gg:murfac=2.0", "isr:g2qq:murfac=0.5", "isr:g2qq:murfac=2.0",
+        "isr:q2qg:murfac=0.5", "isr:q2qg:murfac=2.0", "isr:x2xg:murfac=0.5", "isr:x2xg:murfac=2.0",
+        "isr:g2gg:cns=-2.0",   "isr:g2gg:cns=2.0",    "isr:g2qq:cns=-2.0",   "isr:g2qq:cns=2.0",
+        "isr:q2qg:cns=-2.0",   "isr:q2qg:cns=2.0",    "isr:x2xg:cns=-2.0",   "isr:x2xg:cns=2.0",
+    };
+    const std::vector<std::string> expectedOrder = {
+        "isrRedHi",        "fsrRedHi",        "isrRedLo",        "fsrRedLo",        "isrDefHi",
+        "fsrDefHi",        "isrDefLo",        "fsrDefLo",        "isrConHi",        "fsrConHi",
+        "isrConLo",        "fsrConLo",        "fsr_G2GG_muR_dn", "fsr_G2GG_muR_up", "fsr_G2QQ_muR_dn",
+        "fsr_G2QQ_muR_up", "fsr_Q2QG_muR_dn", "fsr_Q2QG_muR_up", "fsr_X2XG_muR_dn", "fsr_X2XG_muR_up",
+        "fsr_G2GG_cNS_dn", "fsr_G2GG_cNS_up", "fsr_G2QQ_cNS_dn", "fsr_G2QQ_cNS_up", "fsr_Q2QG_cNS_dn",
+        "fsr_Q2QG_cNS_up", "fsr_X2XG_cNS_dn", "fsr_X2XG_cNS_up", "isr_G2GG_muR_dn", "isr_G2GG_muR_up",
+        "isr_G2QQ_muR_dn", "isr_G2QQ_muR_up", "isr_Q2QG_muR_dn", "isr_Q2QG_muR_up", "isr_X2XG_muR_dn",
+        "isr_X2XG_muR_up", "isr_G2GG_cNS_dn", "isr_G2GG_cNS_up", "isr_G2QQ_cNS_dn", "isr_G2QQ_cNS_up",
+        "isr_Q2QG_cNS_dn", "isr_Q2QG_cNS_up", "isr_X2XG_cNS_dn", "isr_X2XG_cNS_up",
     };
   };
 }  // namespace gen

--- a/SimDataFormats/GeneratorProducts/interface/PartonShowerWeightGroupInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/PartonShowerWeightGroupInfo.h
@@ -1,21 +1,11 @@
 #ifndef SimDataFormats_GeneratorProducts_PartonShowerWeightGroupInfo_h
 #define SimDataFormats_GeneratorProducts_PartonShowerWeightGroupInfo_h
 
-#include <map>
-
 #include "SimDataFormats/GeneratorProducts/interface/WeightGroupInfo.h"
 
 namespace gen {
   enum class PSVarType { muR, cNS, con, def, red, alphaS, LAST };
   enum class PSSplittingType { combined, g2gg, x2xg, g2qq, q2qg };
-  typedef std::pair<PSVarType, PSSplittingType> PSPair;
-
-  struct PSPairHash {
-    std::size_t operator()(const PSPair &pair) const {
-      return static_cast<std::size_t>(pair.first) * static_cast<std::size_t>(PSVarType::LAST) +
-             static_cast<std::size_t>(pair.second);
-    }
-  };
 
   class PartonShowerWeightGroupInfo : public WeightGroupInfo {
   public:

--- a/SimDataFormats/GeneratorProducts/interface/PartonShowerWeightGroupInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/PartonShowerWeightGroupInfo.h
@@ -1,21 +1,27 @@
 #ifndef SimDataFormats_GeneratorProducts_PartonShowerWeightGroupInfo_h
 #define SimDataFormats_GeneratorProducts_PartonShowerWeightGroupInfo_h
 
-#include <unordered_map>
+#include <map>
 
 #include "SimDataFormats/GeneratorProducts/interface/WeightGroupInfo.h"
 
 namespace gen {
-  enum class PSVarType { muR, cNS, con, def, red, alphaS };
+  enum class PSVarType { muR, cNS, con, def, red, alphaS, LAST };
   enum class PSSplittingType { combined, g2gg, x2xg, g2qq, q2qg };
+  typedef std::pair<PSVarType, PSSplittingType> PSPair;
+
+  struct PSPairHash {
+    std::size_t operator()(const PSPair &pair) const {
+      return static_cast<std::size_t>(pair.first) * static_cast<std::size_t>(PSVarType::LAST) +
+             static_cast<std::size_t>(pair.second);
+    }
+  };
 
   class PartonShowerWeightGroupInfo : public WeightGroupInfo {
   public:
-    PartonShowerWeightGroupInfo() : PartonShowerWeightGroupInfo("") {}
-    PartonShowerWeightGroupInfo(std::string header, std::string name) : WeightGroupInfo(header, name) {
-      weightType_ = WeightType::kPartonShowerWeights;
-    }
+    PartonShowerWeightGroupInfo(std::string header, std::string name);
     PartonShowerWeightGroupInfo(std::string header) : PartonShowerWeightGroupInfo(header, header) {}
+    PartonShowerWeightGroupInfo() : PartonShowerWeightGroupInfo("") {}
     PartonShowerWeightGroupInfo(const PartonShowerWeightGroupInfo &other) { copy(other); }
     virtual ~PartonShowerWeightGroupInfo() override {}
     void copy(const PartonShowerWeightGroupInfo &other);
@@ -23,10 +29,41 @@ namespace gen {
     void setNameIsPythiaSyntax(bool isPythiaSyntax) { nameIsPythiaSyntax_ = isPythiaSyntax; }
     bool nameIsPythiaSyntax(bool isPythiaSyntax) const { return nameIsPythiaSyntax_; }
     int variationIndex(bool isISR, bool isUp, PSVarType variationType, PSSplittingType splittingType) const;
+    std::string variationName(bool isISR, bool isUp, PSVarType variationType, PSSplittingType splittingType) const;
     int variationIndex(bool isISR, bool isUp, PSVarType variationType) const;
 
   private:
     bool nameIsPythiaSyntax_ = false;
+    typedef PSVarType varType;
+    typedef PSSplittingType sptType;
+    // Order determined by isUp*2 + !isISR -> isrHi, fsrHi, isrLo, fsrLo
+    const std::unordered_map<PSPair, std::vector<int>, PSPairHash> oldPythia_order = {
+        {{varType::def, sptType::combined}, {6, 7, 8, 9}},
+        {{varType::red, sptType::combined}, {2, 3, 4, 5}},
+        {{varType::con, sptType::combined}, {10, 11, 12, 13}},
+        {{varType::muR, sptType::g2gg}, {31, 15, 30, 14}},
+        {{varType::muR, sptType::g2qq}, {33, 17, 32, 16}},
+        {{varType::muR, sptType::q2qg}, {35, 19, 34, 18}},
+        {{varType::muR, sptType::x2xg}, {37, 21, 36, 20}},
+        {{varType::cNS, sptType::g2gg}, {39, 23, 38, 22}},
+        {{varType::cNS, sptType::g2qq}, {41, 25, 40, 24}},
+        {{varType::cNS, sptType::q2qg}, {43, 27, 42, 26}},
+        {{varType::cNS, sptType::x2xg}, {45, 29, 44, 28}},
+    };
+
+    const std::unordered_map<PSPair, std::vector<int>, PSPairHash> newPythia_order = {
+        {{varType::def, sptType::combined}, {27, 5, 26, 4}},
+        {{varType::red, sptType::combined}, {25, 3, 2, 24}},
+        {{varType::con, sptType::combined}, {29, 7, 28, 6}},
+        {{varType::muR, sptType::g2gg}, {31, 9, 30, 8}},
+        {{varType::muR, sptType::g2qq}, {33, 11, 32, 10}},
+        {{varType::muR, sptType::q2qg}, {35, 13, 34, 12}},
+        {{varType::muR, sptType::x2xg}, {37, 15, 36, 14}},
+        {{varType::cNS, sptType::g2gg}, {39, 17, 38, 16}},
+        {{varType::cNS, sptType::g2qq}, {41, 19, 40, 18}},
+        {{varType::cNS, sptType::q2qg}, {43, 21, 42, 20}},
+        {{varType::cNS, sptType::x2xg}, {45, 23, 44, 22}},
+    };
   };
 }  // namespace gen
 

--- a/SimDataFormats/GeneratorProducts/interface/PartonShowerWeightGroupInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/PartonShowerWeightGroupInfo.h
@@ -6,8 +6,8 @@
 #include "SimDataFormats/GeneratorProducts/interface/WeightGroupInfo.h"
 
 namespace gen {
-  enum class PSVarType { muR, cNS, con, def, red, alphaS};
-  enum class PSSplittingType { combined, g2gg, x2xg, g2qq };
+  enum class PSVarType { muR, cNS, con, def, red, alphaS };
+  enum class PSSplittingType { combined, g2gg, x2xg, g2qq, q2qg };
 
   class PartonShowerWeightGroupInfo : public WeightGroupInfo {
   public:

--- a/SimDataFormats/GeneratorProducts/interface/PartonShowerWeightGroupInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/PartonShowerWeightGroupInfo.h
@@ -36,7 +36,7 @@ namespace gen {
     bool nameIsPythiaSyntax_ = false;
     typedef PSVarType varType;
     typedef PSSplittingType sptType;
-    // Order determined by isUp*2 + !isISR -> isrHi, fsrHi, isrLo, fsrLo
+    // Order determined by !isUp*2 + !isISR -> isrHi, fsrHi, isrLo, fsrLo
     const std::unordered_map<PSPair, std::vector<int>, PSPairHash> oldPythia_order = {
         {{varType::def, sptType::combined}, {6, 7, 8, 9}},
         {{varType::red, sptType::combined}, {2, 3, 4, 5}},

--- a/SimDataFormats/GeneratorProducts/interface/ScaleWeightGroupInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/ScaleWeightGroupInfo.h
@@ -12,7 +12,7 @@ namespace gen {
     std::vector<size_t> muIndices_;
     bool containsCentral_ = false;
     int lhaid_ = -1;
-    bool hasAllWeights = false;
+    bool weightIsCorrupt_ = false;
     // Dyn_scale
     std::vector<std::string> dynNames_;
     std::vector<std::vector<size_t>> dynVec_;
@@ -48,7 +48,10 @@ namespace gen {
     virtual ScaleWeightGroupInfo* clone() const override;
     bool containsCentralWeight() const { return containsCentral_; }
     void addContainedId(int globalIndex, std::string id, std::string label, float muR, float muF);
-    bool isWellFormed() { return isWellFormed_ && hasAllWeights; }
+    void setWeightIsCorrupt() {
+      isWellFormed_ = false;
+      weightIsCorrupt_ = true;
+    }
 
     void setMuRMuFIndex(int globalIndex, std::string id, float muR, float muF);
     void setDyn(int globalIndex, std::string id, float muR, float muF, size_t dynNum, std::string dynName);

--- a/SimDataFormats/GeneratorProducts/src/PartonShowerWeightGroupInfo.cc
+++ b/SimDataFormats/GeneratorProducts/src/PartonShowerWeightGroupInfo.cc
@@ -28,15 +28,12 @@ namespace gen {
     std::string varName = variationName(isISR, isUp, variationType, splittingType);
     int wgtIdx = weightIndexFromLabel(varName);
     if (wgtIdx == -1) {
-      int idx = isUp * 2 + !isUp;
+      int idx = !isUp * 2 + !isISR;
       auto pair = std::make_pair(variationType, splittingType);
       wgtIdx = (nameIsPythiaSyntax_) ? newPythia_order.at(pair)[idx] : oldPythia_order.at(pair)[idx];
+      if (wgtIdx > (int)containedIds().size())
+        wgtIdx = -1;
     }
-    std::cout << varName << std::endl;
-    int idx = (!isUp) * 2 + !isISR;
-    auto pair = std::make_pair(variationType, splittingType);
-    int blha = (nameIsPythiaSyntax_) ? newPythia_order.at(pair)[idx] : oldPythia_order.at(pair)[idx];
-    std::cout << wgtIdx << " " << idx << " " << blha << std::endl;
     return wgtIdx;
   }
 

--- a/SimDataFormats/GeneratorProducts/src/PartonShowerWeightGroupInfo.cc
+++ b/SimDataFormats/GeneratorProducts/src/PartonShowerWeightGroupInfo.cc
@@ -3,6 +3,11 @@
 #include <iostream>
 
 namespace gen {
+  PartonShowerWeightGroupInfo::PartonShowerWeightGroupInfo(std::string header, std::string name)
+      : WeightGroupInfo(header, name) {
+    weightType_ = WeightType::kPartonShowerWeights;
+  }
+
   void PartonShowerWeightGroupInfo::copy(const PartonShowerWeightGroupInfo& other) {
     WeightGroupInfo::copy(other);
     nameIsPythiaSyntax_ = other.nameIsPythiaSyntax_;
@@ -20,6 +25,25 @@ namespace gen {
                                                   bool isUp,
                                                   PSVarType variationType,
                                                   PSSplittingType splittingType) const {
+    std::string varName = variationName(isISR, isUp, variationType, splittingType);
+    int wgtIdx = weightIndexFromLabel(varName);
+    if (wgtIdx == -1) {
+      int idx = isUp * 2 + !isUp;
+      auto pair = std::make_pair(variationType, splittingType);
+      wgtIdx = (nameIsPythiaSyntax_) ? newPythia_order.at(pair)[idx] : oldPythia_order.at(pair)[idx];
+    }
+    std::cout << varName << std::endl;
+    int idx = (!isUp) * 2 + !isISR;
+    auto pair = std::make_pair(variationType, splittingType);
+    int blha = (nameIsPythiaSyntax_) ? newPythia_order.at(pair)[idx] : oldPythia_order.at(pair)[idx];
+    std::cout << wgtIdx << " " << idx << " " << blha << std::endl;
+    return wgtIdx;
+  }
+
+  std::string PartonShowerWeightGroupInfo::variationName(bool isISR,
+                                                         bool isUp,
+                                                         PSVarType variationType,
+                                                         PSSplittingType splittingType) const {
     std::string label = isISR ? "isr" : "fsr";
 
     // if ((variationType == PSVarType::con || variationType == PSVarType::def || variationType == PSVarType::red) &&
@@ -72,8 +96,7 @@ namespace gen {
       } else
         label += isUp ? "Hi" : "Lo";
     }
-
-    std::cout << label << std::endl;
-    return weightIndexFromLabel(label);
+    return label;
   }
+
 }  // namespace gen

--- a/SimDataFormats/GeneratorProducts/src/PartonShowerWeightGroupInfo.cc
+++ b/SimDataFormats/GeneratorProducts/src/PartonShowerWeightGroupInfo.cc
@@ -27,13 +27,10 @@ namespace gen {
                                                   PSSplittingType splittingType) const {
     std::string varName = variationName(isISR, isUp, variationType, splittingType);
     int wgtIdx = weightIndexFromLabel(varName);
-    if (wgtIdx == -1) {
-      int idx = !isUp * 2 + !isISR;
-      auto pair = std::make_pair(variationType, splittingType);
-      wgtIdx = (nameIsPythiaSyntax_) ? newPythia_order.at(pair)[idx] : oldPythia_order.at(pair)[idx];
-      if (wgtIdx > (int)containedIds().size())
-        wgtIdx = -1;
-    }
+    // Guess PS idx if not in label list
+    if (wgtIdx == -1 && guessPSWeightIdx_)
+      wgtIdx = psWeightIdxGuess(varName);
+
     return wgtIdx;
   }
 
@@ -94,6 +91,20 @@ namespace gen {
         label += isUp ? "Hi" : "Lo";
     }
     return label;
+  }
+
+  int PartonShowerWeightGroupInfo::psWeightIdxGuess(const std::string& varName) const {
+    int wgtIdx;
+    if (nameIsPythiaSyntax_) {
+      auto wgtIter = std::find(expectedPythiaSyntax.begin(), expectedPythiaSyntax.end(), varName);
+      wgtIdx = wgtIter - expectedPythiaSyntax.begin() + 2;
+    } else {
+      auto wgtIter = std::find(expectedOrder.begin(), expectedOrder.end(), varName);
+      wgtIdx = wgtIter - expectedOrder.begin() + 2;
+    }
+    if (wgtIdx >= (int)containedIds().size())
+      wgtIdx = -1;
+    return wgtIdx;
   }
 
 }  // namespace gen

--- a/SimDataFormats/GeneratorProducts/src/PartonShowerWeightGroupInfo.cc
+++ b/SimDataFormats/GeneratorProducts/src/PartonShowerWeightGroupInfo.cc
@@ -22,57 +22,58 @@ namespace gen {
                                                   PSSplittingType splittingType) const {
     std::string label = isISR ? "isr" : "fsr";
 
-    if ((variationType == PSVarType::con || variationType == PSVarType::def || variationType == PSVarType::red) &&
-        splittingType != PSSplittingType::combined)
-      throw std::invalid_argument("VariationType must be muR or CNS if subprocess is specified");
-
-    std::string variation;
-    switch (variationType) {
-      case PSVarType::con:
-        variation = !nameIsPythiaSyntax_ ? "Con" : (isUp ? "murfac=4.0" : "murfac=0.25");
-        break;
-      case PSVarType::def:
-        variation = !nameIsPythiaSyntax_ ? "Def" : (isUp ? "murfac=2.0" : "murfac=0.5");
-        break;
-      case PSVarType::red:
-        variation = !nameIsPythiaSyntax_ ? "Red" : (isUp ? "murfac=1.414" : "murfac=0.707");
-      case PSVarType::muR:
-        variation = !nameIsPythiaSyntax_ ? "muR" : (isUp ? "murfac=2.0" : "murfac=0.5");
-        break;
-      case PSVarType::cNS:
-        variation = !nameIsPythiaSyntax_ ? "cNS" : (isUp ? "cns=2.0" : "murfac=-2.0");
-        break;
-      case PSVarType::alphaS:
-        variation = (isUp ? "alpsfact=2.0" : "alpsfact=0.5");
-        return weightIndexFromLabel(variation);
-    }
-
-    std::string splitting;
-    switch (splittingType) {
-      case PSSplittingType::g2gg:
-        splitting = !nameIsPythiaSyntax_ ? "G2GG" : "g2gg";
-        break;
-      case PSSplittingType::g2qq:
-        splitting = !nameIsPythiaSyntax_ ? "G2QQ" : "g2qq";
-        break;
-      case PSSplittingType::x2xg:
-        splitting = !nameIsPythiaSyntax_ ? "X2XG" : "x2xg";
-        break;
-      default:
-        break;
-    }
+    // if ((variationType == PSVarType::con || variationType == PSVarType::def || variationType == PSVarType::red) &&
+    //     splittingType != PSSplittingType::combined)
+    //   throw std::invalid_argument("VariationType must be muR or CNS if subprocess is specified");
 
     if (nameIsPythiaSyntax_) {
-      std::string app = splittingType != PSSplittingType::combined ? splitting + ":" + variation : variation;
-      label += ":" + app;
+      // Splitting
+      if (splittingType == PSSplittingType::g2gg)
+        label += ":g2gg";
+      else if (splittingType == PSSplittingType::g2qq)
+        label += ":g2qq";
+      else if (splittingType == PSSplittingType::x2xg)
+        label += ":x2xg";
+      else if (splittingType == PSSplittingType::q2qg)
+        label += ":q2qg";
+      // type
+      if (variationType == PSVarType::con)
+        label += isUp ? ":murfac=4.0" : ":murfac=0.25";
+      else if (variationType == PSVarType::def || variationType == PSVarType::muR)
+        label += isUp ? ":murfac=2.0" : ":murfac=0.5";
+      else if (variationType == PSVarType::red)
+        label += isUp ? ":murfac=1.414" : ":murfac=0.707";
+      else if (variationType == PSVarType::cNS)
+        label += isUp ? ":cns=2.0" : ":cns=-2.0";
     } else {
+      // Splitting
+      if (splittingType == PSSplittingType::g2gg)
+        label += "_G2GG_";
+      else if (splittingType == PSSplittingType::g2qq)
+        label += "_G2QQ_";
+      else if (splittingType == PSSplittingType::x2xg)
+        label += "_X2XG_";
+      else if (splittingType == PSSplittingType::q2qg)
+        label += "_Q2QG_";
+      // type
+      if (variationType == PSVarType::con)
+        label += "Con";
+      else if (variationType == PSVarType::def)
+        label += "Def";
+      else if (variationType == PSVarType::muR)
+        label += "muR";
+      else if (variationType == PSVarType::red)
+        label += "Red";
+      else if (variationType == PSVarType::cNS)
+        label += "cNS";
+      // Up/Down
       if (splittingType != PSSplittingType::combined) {
-        label += variation + "_" + splitting + "_" + variation + (isUp ? "_up" : "_dn");
+        label += isUp ? "_up" : "_dn";
       } else
-        label += variation + (isUp ? "Hi" : "Lo");
+        label += isUp ? "Hi" : "Lo";
     }
 
+    std::cout << label << std::endl;
     return weightIndexFromLabel(label);
   }
-
 }  // namespace gen

--- a/SimDataFormats/GeneratorProducts/src/ScaleWeightGroupInfo.cc
+++ b/SimDataFormats/GeneratorProducts/src/ScaleWeightGroupInfo.cc
@@ -26,18 +26,13 @@ namespace gen {
     }
     WeightGroupInfo::addContainedId(globalIndex, id, label);
     setMuRMuFIndex(globalIndex, id, muR, muF);
-    std::cout << hasAllWeights << " " << isWellFormed_ << std::endl;
-    for (int muidx : muIndices_) {
-      std::cout << muidx << " ";
-    }
-    std::cout << std::endl;
   }
 
   void ScaleWeightGroupInfo::setMuRMuFIndex(int globalIndex, std::string id, float muR, float muF) {
     auto info = weightMetaInfoByGlobalIndex(id, globalIndex);
     int index = indexFromMus(muR, muF);
     if (!(isValidValue(muR) && isValidValue(muF))) {
-      isWellFormed_ = false;
+      setWeightIsCorrupt();
       return;
     }
     if (index == Central_idx)
@@ -48,7 +43,7 @@ namespace gen {
       if (muidx == -1)
         return;
     }
-    hasAllWeights = true;
+    isWellFormed_ = !weightIsCorrupt_;
   }
 
   void ScaleWeightGroupInfo::setDyn(


### PR DESCRIPTION
## Overview

This tried to expand the functionality of the PS weights in the refactor of the GEN weight code. It replaces the case statements with if statements and adds hardcoded lists for different weights to handle files with "gaps" in the LumiHeader

There are still print out statements used for testing in the code, but after this has been approved then they can be removed and these commits squashed

@kdlong